### PR TITLE
feat: Changes migrations to array to catch duplicate keys.

### DIFF
--- a/src/RepoFacade.ts
+++ b/src/RepoFacade.ts
@@ -1,8 +1,8 @@
-import MigrationDictionary from './utils/types/MigrationDictionary';
+import Migration from './utils/types/Migration';
 import ProcessedMigration from './utils/types/ProcessedMigration';
 
 export default interface RepoFacade {
-  readonly getMigrations: () => Promise<MigrationDictionary>;
+  readonly getMigrations: () => Promise<Migration[]>;
   readonly getProcessedMigrations: () => Promise<ProcessedMigration[]>;
   readonly updateProcessedMigration: (migration: ProcessedMigration) => Promise<void>;
   readonly removeProcessedMigration: (key: string) => Promise<void>;

--- a/src/factoryTest.ts
+++ b/src/factoryTest.ts
@@ -7,7 +7,7 @@ import TestFactory from './utils/tests/TestFactory';
 const testFactory: TestFactory = (repoFactory) => {
   describe('factory', () => {
     beforeEach(async () => {
-      await repoFactory({}).clearMigrations();
+      await repoFactory([]).clearMigrations();
     });
 
     migrateTest(repoFactory);

--- a/src/migrate/test.ts
+++ b/src/migrate/test.ts
@@ -2,79 +2,87 @@ import * as assert from 'assert';
 import * as assertRejects from 'assert-rejects';
 import 'mocha'; // tslint:disable-line:no-import-side-effect
 import factory from '../factory';
+import DuplicateKeyError from '../utils/errors/DuplicateKeyError';
 import FailingMigrationError from '../utils/errors/FailingMigrationError';
 import assertLocked from '../utils/tests/assertLocked';
 import createMigrationProcess from '../utils/tests/createMigrationProcess';
 import createTestUpMigration from '../utils/tests/createTestUpMigration';
 import TestFactory from '../utils/tests/TestFactory';
-import MigrationDictionary from '../utils/types/MigrationDictionary';
+import Migration from '../utils/types/Migration';
 
 const testMigrate: TestFactory = (repoFactory) => {
-  const successfulMigration = createTestUpMigration();
-  const failingMigration = createTestUpMigration(() => { throw new Error(); });
+  const successfulMigration = createTestUpMigration(undefined, 'successfulMigration');
+  const failingMigration = createTestUpMigration(() => { throw new Error(); }, 'failingMigration');
+  const skippableKey = 'skippableMigration';
+  const skippableMigration = createTestUpMigration(undefined, skippableKey);
 
-  const createService = (migrations: MigrationDictionary) => {
+  const createService = (migrations: Migration[] = []) => {
     const log = () => null;
     return factory({ log, repo: repoFactory(migrations) });
   };
 
   describe('migrate', () => {
     it('should not error when there are no migrations', async () => {
-      const service = createService({});
+      const service = createService();
       await service.migrate();
     });
 
+    it('should error when there are duplicate keys', async () => {
+      const service = createService([createTestUpMigration(), createTestUpMigration()]);
+      const promise = service.migrate();
+      await assertRejects(promise, DuplicateKeyError);
+    });
+
     it('should error when the first migration errors', async () => {
-      const promise = createService({ failingMigration, successfulMigration }).migrate();
+      const promise = createService([failingMigration, successfulMigration]).migrate();
       await assertRejects(promise, FailingMigrationError);
     });
 
     it('should error when the second migration errors', async () => {
-      const promise = createService({ successfulMigration, failingMigration }).migrate();
+      const promise = createService([successfulMigration, failingMigration]).migrate();
       await assertRejects(promise, FailingMigrationError);
     });
 
     it('should process migrations', async () => {
       const { process, getProcessed } = createMigrationProcess();
-      const service = createService({ testMigration: createTestUpMigration(process) });
+      const service = createService([createTestUpMigration(process)]);
       await service.migrate();
       assert.equal(getProcessed(), true);
     });
 
     it('should not reprocess migrations', async () => {
       const { process, getProcessed } = createMigrationProcess();
-      await createService({ testMigration: createTestUpMigration() }).migrate();
-      await createService({ testMigration: createTestUpMigration(process) }).migrate();
+      await createService([createTestUpMigration()]).migrate();
+      await createService([createTestUpMigration(process)]).migrate();
       assert.equal(getProcessed(), false);
     });
 
     it('should skip processed migrations after unprocessed migrations', async () => {
-      const skippedMigration = createMigrationProcess();
-      const unskippedMigration = createMigrationProcess();
-      await createService({ migrationToSkip: createTestUpMigration() }).migrate();
-      await createService({
-        migrationToProcess: createTestUpMigration(unskippedMigration.process),
-        migrationToSkip: createTestUpMigration(skippedMigration.process),
-      }).migrate();
-      assert.equal(skippedMigration.getProcessed(), false);
-      assert.equal(unskippedMigration.getProcessed(), true);
+      const skippedProcess = createMigrationProcess();
+      const unskippedProcess = createMigrationProcess();
+      await createService([skippableMigration]).migrate();
+      await createService([
+        createTestUpMigration(unskippedProcess.process),
+        createTestUpMigration(skippedProcess.process, skippableKey),
+      ]).migrate();
+      assert.equal(skippedProcess.getProcessed(), false);
+      assert.equal(unskippedProcess.getProcessed(), true);
     });
 
     it('should skip processed migrations before unprocessed migrations', async () => {
-      const skippedMigration = createMigrationProcess();
-      const unskippedMigration = createMigrationProcess();
-      await createService({ migrationToSkip: createTestUpMigration() }).migrate();
-      await createService({
-        migrationToSkip: createTestUpMigration(skippedMigration.process),
-        // tslint:disable-next-line:object-literal-sort-keys
-        migrationToProcess: createTestUpMigration(unskippedMigration.process),
-      }).migrate();
-      assert.equal(skippedMigration.getProcessed(), false);
-      assert.equal(unskippedMigration.getProcessed(), true);
+      const skippedProcess = createMigrationProcess();
+      const unskippedProcess = createMigrationProcess();
+      await createService([skippableMigration]).migrate();
+      await createService([
+        createTestUpMigration(skippedProcess.process, skippableKey),
+        createTestUpMigration(unskippedProcess.process),
+      ]).migrate();
+      assert.equal(skippedProcess.getProcessed(), false);
+      assert.equal(unskippedProcess.getProcessed(), true);
     });
 
     it('should error when migrations are locked', async () => {
-      const service = createService({});
+      const service = createService();
       await assertLocked([service.migrate(), service.migrate()]);
     });
   });

--- a/src/migrateByKey/test.ts
+++ b/src/migrateByKey/test.ts
@@ -2,66 +2,73 @@ import * as assert from 'assert';
 import * as assertRejects from 'assert-rejects';
 import 'mocha'; // tslint:disable-line:no-import-side-effect
 import factory from '../factory';
+import DuplicateKeyError from '../utils/errors/DuplicateKeyError';
 import FailingMigrationError from '../utils/errors/FailingMigrationError';
 import MissingMigrationError from '../utils/errors/MissingMigrationError';
 import ProcessedMigrationError from '../utils/errors/ProcessedMigrationError';
 import assertLocked from '../utils/tests/assertLocked';
 import createMigrationProcess from '../utils/tests/createMigrationProcess';
-import createTestUpMigration from '../utils/tests/createTestUpMigration';
+import createTestUpMigration, { testMigrationKey } from '../utils/tests/createTestUpMigration';
 import TestFactory from '../utils/tests/TestFactory';
-import MigrationDictionary from '../utils/types/MigrationDictionary';
+import Migration from '../utils/types/Migration';
 
 const testMigrateByKey: TestFactory = (repoFactory) => {
   const successfulMigration = createTestUpMigration();
   const failingMigration = createTestUpMigration(() => { throw new Error(); });
 
-  const createService = (migrations: MigrationDictionary) => {
+  const createService = (migrations: Migration[] = []) => {
     const log = () => null;
     return factory({ log, repo: repoFactory(migrations) });
   };
 
   describe('migrateByKey', () => {
     it('should error when the migration is missing', async () => {
-      const service = createService({});
+      const service = createService();
       const promise = service.migrateByKey({ key: 'missingKey' });
       await assertRejects(promise, MissingMigrationError);
     });
 
+    it('should error when there are duplicate keys', async () => {
+      const service = createService([createTestUpMigration(), createTestUpMigration()]);
+      const promise = service.migrateByKey({ key: testMigrationKey });
+      await assertRejects(promise, DuplicateKeyError);
+    });
+
     it('should error when the migration errors', async () => {
-      const service = createService({ failingMigration });
-      const promise = service.migrateByKey({ key: 'failingMigration' });
+      const service = createService([failingMigration]);
+      const promise = service.migrateByKey({ key: testMigrationKey });
       await assertRejects(promise, FailingMigrationError);
     });
 
     it('should process migration', async () => {
       const { process, getProcessed } = createMigrationProcess();
-      const service = createService({ testMigration: createTestUpMigration(process) });
-      await service.migrateByKey({ key: 'testMigration' });
+      const service = createService([createTestUpMigration(process)]);
+      await service.migrateByKey({ key: testMigrationKey });
       assert.equal(getProcessed(), true);
     });
 
     it('should error when reprocessing migrations without force', async () => {
       const { process, getProcessed } = createMigrationProcess();
-      await createService({ testMigration: createTestUpMigration() }).migrate();
-      const service = createService({ testMigration: createTestUpMigration(process) });
-      const promise = service.migrateByKey({ key: 'testMigration' });
+      await createService([createTestUpMigration()]).migrate();
+      const service = createService([createTestUpMigration(process)]);
+      const promise = service.migrateByKey({ key: testMigrationKey });
       await assertRejects(promise, ProcessedMigrationError);
       assert.equal(getProcessed(), false);
     });
 
     it('should reprocess migration when using force', async () => {
       const { process, getProcessed } = createMigrationProcess();
-      await createService({ testMigration: createTestUpMigration() }).migrate();
-      const service = createService({ testMigration: createTestUpMigration(process) });
-      await service.migrateByKey({ key: 'testMigration', force: true });
+      await createService([createTestUpMigration()]).migrate();
+      const service = createService([createTestUpMigration(process)]);
+      await service.migrateByKey({ key: testMigrationKey, force: true });
       assert.equal(getProcessed(), true);
     });
 
     it('should error when migrations are locked', async () => {
-      const service = createService({ successfulMigration });
+      const service = createService([successfulMigration]);
       await assertLocked([
-        service.migrateByKey({ key: 'successfulMigration' }),
-        service.migrateByKey({ key: 'successfulMigration' }),
+        service.migrateByKey({ key: testMigrationKey }),
+        service.migrateByKey({ key: testMigrationKey }),
       ]);
     });
   });

--- a/src/rollback/test.ts
+++ b/src/rollback/test.ts
@@ -1,45 +1,58 @@
+// tslint:disable:max-file-line-count
 import * as assert from 'assert';
 import * as assertRejects from 'assert-rejects';
 import 'mocha'; // tslint:disable-line:no-import-side-effect
 import factory from '../factory';
+import DuplicateKeyError from '../utils/errors/DuplicateKeyError';
 import FailingMigrationError from '../utils/errors/FailingMigrationError';
 import MissingMigrationError from '../utils/errors/MissingMigrationError';
 import assertLocked from '../utils/tests/assertLocked';
 import createMigrationProcess from '../utils/tests/createMigrationProcess';
 import createTestDownMigration from '../utils/tests/createTestDownMigration';
 import TestFactory from '../utils/tests/TestFactory';
-import MigrationDictionary from '../utils/types/MigrationDictionary';
+import Migration from '../utils/types/Migration';
 
 const testRollback: TestFactory = (repoFactory) => {
-  const successfulMigration = createTestDownMigration();
-  const failingMigration = createTestDownMigration(() => { throw new Error(); });
+  const successfulMigration = createTestDownMigration(undefined, 'successfulMigration');
+  const failingMigration = createTestDownMigration(() => {
+    throw new Error();
+  }, 'failingMigration');
+  const unskippableKey = 'unskippableMigration';
+  const unskippableMigration = createTestDownMigration(undefined, unskippableKey);
 
-  const createService = (migrations: MigrationDictionary) => {
+  const createService = (migrations: Migration[] = []) => {
     const log = () => null;
     return factory({ log, repo: repoFactory(migrations) });
   };
 
   describe('rollback', () => {
     it('should not error when there are no migrations', async () => {
-      const service = createService({});
+      const service = createService();
       await service.rollback();
     });
 
+    it('should error when there are duplicate keys', async () => {
+      await createService([createTestDownMigration()]).migrate();
+      const service = createService([createTestDownMigration(), createTestDownMigration()]);
+      const promise = service.rollback();
+      await assertRejects(promise, DuplicateKeyError);
+    });
+
     it('should error when a processed migration is missing', async () => {
-      await createService({ successfulMigration }).migrate();
-      const promise = createService({}).rollback();
+      await createService([successfulMigration]).migrate();
+      const promise = createService().rollback();
       await assertRejects(promise, MissingMigrationError);
     });
 
     it('should error when the first migration errors', async () => {
-      const service = createService({ failingMigration, successfulMigration });
+      const service = createService([failingMigration, successfulMigration]);
       await service.migrate();
       const promise = service.rollback();
       await assertRejects(promise, FailingMigrationError);
     });
 
     it('should error when the second migration errors', async () => {
-      const service = createService({ successfulMigration, failingMigration });
+      const service = createService([successfulMigration, failingMigration]);
       await service.migrate();
       const promise = service.rollback();
       await assertRejects(promise, FailingMigrationError);
@@ -47,7 +60,7 @@ const testRollback: TestFactory = (repoFactory) => {
 
     it('should process rollback for a processed migration', async () => {
       const { process, getProcessed } = createMigrationProcess();
-      const service = createService({ testMigration: createTestDownMigration(process) });
+      const service = createService([createTestDownMigration(process)]);
       await service.migrate();
       await service.rollback();
       assert.equal(getProcessed(), true);
@@ -55,38 +68,37 @@ const testRollback: TestFactory = (repoFactory) => {
 
     it('should not process rollback for a unprocessed migration', async () => {
       const { process, getProcessed } = createMigrationProcess();
-      const service = createService({ testMigration: createTestDownMigration(process) });
+      const service = createService([createTestDownMigration(process)]);
       await service.rollback();
       assert.equal(getProcessed(), false);
     });
 
-    it('should skip processed migrations after unprocessed migrations', async () => {
-      const skippedMigration = createMigrationProcess();
-      const unskippedMigration = createMigrationProcess();
-      await createService({ migrationToProcess: createTestDownMigration() }).migrate();
-      await createService({
-        migrationToProcess: createTestDownMigration(unskippedMigration.process),
-        migrationToSkip: createTestDownMigration(skippedMigration.process),
-      }).rollback();
-      assert.equal(skippedMigration.getProcessed(), false);
-      assert.equal(unskippedMigration.getProcessed(), true);
+    it('should skip unprocessed migrations after processed migrations', async () => {
+      const skippedProcess = createMigrationProcess();
+      const unskippedProcess = createMigrationProcess();
+      await createService([unskippableMigration]).migrate();
+      await createService([
+        createTestDownMigration(unskippedProcess.process, unskippableKey),
+        createTestDownMigration(skippedProcess.process),
+      ]).rollback();
+      assert.equal(skippedProcess.getProcessed(), false);
+      assert.equal(unskippedProcess.getProcessed(), true);
     });
 
-    it('should skip processed migrations before unprocessed migrations', async () => {
-      const skippedMigration = createMigrationProcess();
-      const unskippedMigration = createMigrationProcess();
-      await createService({ migrationToProcess: createTestDownMigration() }).migrate();
-      await createService({
-        migrationToSkip: createTestDownMigration(skippedMigration.process),
-        // tslint:disable-next-line:object-literal-sort-keys
-        migrationToProcess: createTestDownMigration(unskippedMigration.process),
-      }).rollback();
-      assert.equal(skippedMigration.getProcessed(), false);
-      assert.equal(unskippedMigration.getProcessed(), true);
+    it('should skip unprocessed migrations before processed migrations', async () => {
+      const skippedProcess = createMigrationProcess();
+      const unskippedProcess = createMigrationProcess();
+      await createService([unskippableMigration]).migrate();
+      await createService([
+        createTestDownMigration(skippedProcess.process),
+        createTestDownMigration(unskippedProcess.process, unskippableKey),
+      ]).rollback();
+      assert.equal(skippedProcess.getProcessed(), false);
+      assert.equal(unskippedProcess.getProcessed(), true);
     });
 
     it('should error when migrations are locked', async () => {
-      const service = createService({});
+      const service = createService();
       await assertLocked([service.rollback(), service.rollback()]);
     });
   });

--- a/src/utils/errors/DuplicateKeyError.ts
+++ b/src/utils/errors/DuplicateKeyError.ts
@@ -1,0 +1,8 @@
+// tslint:disable:no-class
+import { BaseError } from 'make-error';
+
+export default class DuplicateKeyError extends BaseError {
+  constructor(public key: string) {
+    super();
+  }
+}

--- a/src/utils/getMigrationByKey.ts
+++ b/src/utils/getMigrationByKey.ts
@@ -1,13 +1,18 @@
-import { has } from 'lodash';
+import DuplicateKeyError from './errors/DuplicateKeyError';
 import MissingMigrationError from './errors/MissingMigrationError';
 import Migration from './types/Migration';
 
-export default (migrations: { readonly [key: string]: Migration }, key: string): Migration => {
-  const migration = migrations[key];
+export default (migrations: Migration[], key: string): Migration => {
+  const matchingMigrations = migrations.filter((migration) => {
+    return migration.key === key;
+  });
 
-  if (!has(migrations, key)) {
+  if (matchingMigrations.length === 0) {
     throw new MissingMigrationError(key);
   }
+  if (matchingMigrations.length > 1) {
+    throw new DuplicateKeyError(key);
+  }
 
-  return migration;
+  return matchingMigrations[0];
 };

--- a/src/utils/getUnprocessedKeys.ts
+++ b/src/utils/getUnprocessedKeys.ts
@@ -2,9 +2,11 @@ import { difference } from 'lodash';
 import FacadeConfig from '../FacadeConfig';
 
 export default async (config: FacadeConfig) => {
-  const processedMigrations = await config.repo.getProcessedMigrations();
-  const migrations = await config.repo.getMigrations();
+  const [migrations, processedMigrations] = await Promise.all([
+    config.repo.getMigrations(),
+    config.repo.getProcessedMigrations(),
+  ]);
   const processedKeys = processedMigrations.map(({ key }) => key);
-  const migrationKeys = Object.keys(migrations);
+  const migrationKeys = migrations.map(({ key }) => key);
   return difference(migrationKeys, processedKeys);
 };

--- a/src/utils/tests/TestFactory.ts
+++ b/src/utils/tests/TestFactory.ts
@@ -1,6 +1,6 @@
 import RepoFacade from '../../RepoFacade';
-import MigrationDictionary from '../types/MigrationDictionary';
+import Migration from '../types/Migration';
 
-type TestFactory = (repoFactory: (migrations: MigrationDictionary) => RepoFacade) => void;
+type TestFactory = (repoFactory: (migrations: Migration[]) => RepoFacade) => void;
 
 export default TestFactory;

--- a/src/utils/tests/createTestDownMigration.ts
+++ b/src/utils/tests/createTestDownMigration.ts
@@ -1,8 +1,7 @@
 import Migration from '../types/Migration';
 
-export default (process: Function = () => null): Migration => {
-  return {
-    down: async () => { return process(); },
-    up: async () => { return; },
-  };
+export default (process: Function = () => null, key = 'testMigration'): Migration => {
+  const down = async () => { return process(); };
+  const up = async () => { /* istanbul ignore next */ };
+  return { down, key, up };
 };

--- a/src/utils/tests/createTestUpMigration.ts
+++ b/src/utils/tests/createTestUpMigration.ts
@@ -1,11 +1,9 @@
 import Migration from '../types/Migration';
 
-export default (process: Function = () => null): Migration => {
-  return {
-    down: async () => {
-      /* istanbul ignore next */
-      return;
-    },
-    up: async () => { return process(); },
-  };
+export const testMigrationKey = 'testMigration';
+
+export default (process: Function = () => null, key = testMigrationKey): Migration => {
+  const down = async () => { /* istanbul ignore next */ };
+  const up = async () => { return process(); };
+  return { down, key, up };
 };

--- a/src/utils/types/Migration.ts
+++ b/src/utils/types/Migration.ts
@@ -1,4 +1,5 @@
 export default interface Migration {
+  readonly key: string;
   readonly up: () => Promise<void>;
   readonly down: () => Promise<void>;
 }

--- a/src/utils/types/MigrationDictionary.ts
+++ b/src/utils/types/MigrationDictionary.ts
@@ -1,5 +1,0 @@
-import Migration from './Migration';
-
-export default interface MigrationDictionary {
-  readonly [key: string]: Migration;
-}


### PR DESCRIPTION
BREAKING CHANGE: Changes migrations to `Migration[]` instead of `MigrationDictionary`.