### PR TITLE
test: Uses service factory instead of repo factory.

### DIFF
--- a/src/Facade.ts
+++ b/src/Facade.ts
@@ -2,8 +2,11 @@ import MigrateSignature from './migrate/Signature';
 import MigrateByKeySignature from './migrateByKey/Signature';
 import RollbackSignature from './rollback/Signature';
 import RollbackByKeySignature from './rollbackByKey/Signature';
+import Migration from './utils/types/Migration';
 
 export default interface Facade {
+  readonly clearMigrations: () => Promise<void>;
+  readonly getMigrations: () => Promise<Migration[]>;
   readonly migrate: MigrateSignature;
   readonly migrateByKey: MigrateByKeySignature;
   readonly rollback: RollbackSignature;

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -1,7 +1,11 @@
 import * as sourceMapSupport from 'source-map-support';
 sourceMapSupport.install();
 
+import factory from './factory';
 import factoryTest from './factoryTest';
 import testRepoFactory from './utils/tests/testRepoFactory';
 
-factoryTest(testRepoFactory);
+factoryTest((migrations) => {
+  const log = () => null;
+  return factory({ log, repo: testRepoFactory(migrations) });
+});

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -7,6 +7,8 @@ import rollbackByKey from './rollbackByKey';
 
 export default (config: FacadeConfig): Facade => {
   return {
+    clearMigrations: config.repo.clearMigrations,
+    getMigrations: config.repo.getMigrations,
     migrate: migrate(config),
     migrateByKey: migrateByKey(config),
     rollback: rollback(config),

--- a/src/factoryTest.ts
+++ b/src/factoryTest.ts
@@ -4,16 +4,16 @@ import rollbackTest from './rollback/test';
 import rollbackByKeyTest from './rollbackByKey/test';
 import TestFactory from './utils/tests/TestFactory';
 
-const testFactory: TestFactory = (repoFactory) => {
+const testFactory: TestFactory = (serviceFactory) => {
   describe('factory', () => {
     beforeEach(async () => {
-      await repoFactory([]).clearMigrations();
+      await serviceFactory([]).clearMigrations();
     });
 
-    migrateTest(repoFactory);
-    migrateByKeyTest(repoFactory);
-    rollbackTest(repoFactory);
-    rollbackByKeyTest(repoFactory);
+    migrateTest(serviceFactory);
+    migrateByKeyTest(serviceFactory);
+    rollbackTest(serviceFactory);
+    rollbackByKeyTest(serviceFactory);
   });
 };
 

--- a/src/migrate/test.ts
+++ b/src/migrate/test.ts
@@ -1,29 +1,22 @@
 import * as assert from 'assert';
 import * as assertRejects from 'assert-rejects';
 import 'mocha'; // tslint:disable-line:no-import-side-effect
-import factory from '../factory';
 import DuplicateKeyError from '../utils/errors/DuplicateKeyError';
 import FailingMigrationError from '../utils/errors/FailingMigrationError';
 import assertLocked from '../utils/tests/assertLocked';
 import createMigrationProcess from '../utils/tests/createMigrationProcess';
 import createTestUpMigration from '../utils/tests/createTestUpMigration';
 import TestFactory from '../utils/tests/TestFactory';
-import Migration from '../utils/types/Migration';
 
-const testMigrate: TestFactory = (repoFactory) => {
+const testMigrate: TestFactory = (createService) => {
   const successfulMigration = createTestUpMigration(undefined, 'successfulMigration');
   const failingMigration = createTestUpMigration(() => { throw new Error(); }, 'failingMigration');
   const skippableKey = 'skippableMigration';
   const skippableMigration = createTestUpMigration(undefined, skippableKey);
 
-  const createService = (migrations: Migration[] = []) => {
-    const log = () => null;
-    return factory({ log, repo: repoFactory(migrations) });
-  };
-
   describe('migrate', () => {
     it('should not error when there are no migrations', async () => {
-      const service = createService();
+      const service = createService([]);
       await service.migrate();
     });
 
@@ -82,7 +75,7 @@ const testMigrate: TestFactory = (repoFactory) => {
     });
 
     it('should error when migrations are locked', async () => {
-      const service = createService();
+      const service = createService([]);
       await assertLocked([service.migrate(), service.migrate()]);
     });
   });

--- a/src/migrateByKey/test.ts
+++ b/src/migrateByKey/test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
 import * as assertRejects from 'assert-rejects';
 import 'mocha'; // tslint:disable-line:no-import-side-effect
-import factory from '../factory';
 import DuplicateKeyError from '../utils/errors/DuplicateKeyError';
 import FailingMigrationError from '../utils/errors/FailingMigrationError';
 import MissingMigrationError from '../utils/errors/MissingMigrationError';
@@ -10,20 +9,14 @@ import assertLocked from '../utils/tests/assertLocked';
 import createMigrationProcess from '../utils/tests/createMigrationProcess';
 import createTestUpMigration, { testMigrationKey } from '../utils/tests/createTestUpMigration';
 import TestFactory from '../utils/tests/TestFactory';
-import Migration from '../utils/types/Migration';
 
-const testMigrateByKey: TestFactory = (repoFactory) => {
+const testMigrateByKey: TestFactory = (createService) => {
   const successfulMigration = createTestUpMigration();
   const failingMigration = createTestUpMigration(() => { throw new Error(); });
 
-  const createService = (migrations: Migration[] = []) => {
-    const log = () => null;
-    return factory({ log, repo: repoFactory(migrations) });
-  };
-
   describe('migrateByKey', () => {
     it('should error when the migration is missing', async () => {
-      const service = createService();
+      const service = createService([]);
       const promise = service.migrateByKey({ key: 'missingKey' });
       await assertRejects(promise, MissingMigrationError);
     });

--- a/src/rollbackByKey/test.ts
+++ b/src/rollbackByKey/test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
 import * as assertRejects from 'assert-rejects';
 import 'mocha'; // tslint:disable-line:no-import-side-effect
-import factory from '../factory';
 import DuplicateKeyError from '../utils/errors/DuplicateKeyError';
 import FailingMigrationError from '../utils/errors/FailingMigrationError';
 import UnprocessedMigrationError from '../utils/errors/UnprocessedMigrationError';
@@ -10,20 +9,14 @@ import createMigrationProcess from '../utils/tests/createMigrationProcess';
 import createTestDownMigration from '../utils/tests/createTestDownMigration';
 import { testMigrationKey } from '../utils/tests/createTestUpMigration';
 import TestFactory from '../utils/tests/TestFactory';
-import Migration from '../utils/types/Migration';
 
-const testRollbackByKey: TestFactory = (repoFactory) => {
+const testRollbackByKey: TestFactory = (createService) => {
   const successfulMigration = createTestDownMigration();
   const failingMigration = createTestDownMigration(() => { throw new Error(); });
 
-  const createService = (migrations: Migration[] = []) => {
-    const log = () => null;
-    return factory({ log, repo: repoFactory(migrations) });
-  };
-
   describe('rollbackByKey', () => {
     it('should error when the migration is missing', async () => {
-      const service = createService();
+      const service = createService([]);
       const promise = service.rollbackByKey({ key: 'missingKey' });
       await assertRejects(promise, UnprocessedMigrationError);
     });

--- a/src/utils/tests/TestFactory.ts
+++ b/src/utils/tests/TestFactory.ts
@@ -1,6 +1,6 @@
-import RepoFacade from '../../RepoFacade';
+import Facade from '../../Facade';
 import Migration from '../types/Migration';
 
-type TestFactory = (repoFactory: (migrations: Migration[]) => RepoFacade) => void;
+type TestFactory = (serviceFactory: (migrations: Migration[]) => Facade) => void;
 
 export default TestFactory;


### PR DESCRIPTION
BREAKING CHANGE: Tests in `RepoFacade` implementations need to use a service factory.