### PR TITLE
feat: Improves recording of processed migrations.

### DIFF
--- a/src/RepoFacade.ts
+++ b/src/RepoFacade.ts
@@ -4,7 +4,7 @@ import ProcessedMigration from './utils/types/ProcessedMigration';
 export default interface RepoFacade {
   readonly getMigrations: () => Promise<Migration[]>;
   readonly getProcessedMigrations: () => Promise<ProcessedMigration[]>;
-  readonly updateProcessedMigration: (migration: ProcessedMigration) => Promise<void>;
+  readonly recordProcessedMigration: (migration: ProcessedMigration) => Promise<void>;
   readonly removeProcessedMigration: (key: string) => Promise<void>;
   readonly clearMigrations: () => Promise<void>;
   readonly lockMigrations: () => Promise<void>;

--- a/src/utils/getLastBatchKeys.ts
+++ b/src/utils/getLastBatchKeys.ts
@@ -3,7 +3,7 @@ import FacadeConfig from '../FacadeConfig';
 
 export default async (config: FacadeConfig) => {
   const processedMigrations = await config.repo.getProcessedMigrations();
-  const batchStarts = processedMigrations.map((migration) => migration.lastBatch);
+  const batchStarts = processedMigrations.map((migration) => migration.batchStart);
   const sortedBatchStarts = batchStarts.sort();
   const lastBatchStart = last(sortedBatchStarts);
 
@@ -13,7 +13,7 @@ export default async (config: FacadeConfig) => {
 
   const lastBatchIsoStart = lastBatchStart.toISOString();
   const lastBatchMigrations = processedMigrations.filter((migration) => {
-    return migration.lastBatch.toISOString() === lastBatchIsoStart;
+    return migration.batchStart.toISOString() === lastBatchIsoStart;
   });
   return lastBatchMigrations.map((migration) => migration.key);
 };

--- a/src/utils/migrateKey.ts
+++ b/src/utils/migrateKey.ts
@@ -15,16 +15,18 @@ export default async ({ config, key, batchStart, dryRun }: Opts) => {
   const selectedMigration = getMigrationByKey(migrations, key);
   config.log(`Starting to migrate with ${key}`);
   if (!dryRun) {
-    const migrationStart = new Date();
+    const processStart = new Date();
     try {
       await selectedMigration.up();
     } catch (err) {
       throw new FailingMigrationError(key, err);
     }
-    await config.repo.updateProcessedMigration({
+    const processEnd = new Date();
+    await config.repo.recordProcessedMigration({
+      batchStart: defaultTo(batchStart, processStart),
       key,
-      lastBatch: defaultTo(batchStart, migrationStart),
-      lastStart: migrationStart,
+      processEnd,
+      processStart,
     });
   }
   config.log(`Completed migration with ${key}`);

--- a/src/utils/tests/testRepoFactory.ts
+++ b/src/utils/tests/testRepoFactory.ts
@@ -23,6 +23,9 @@ const testRepoFactory = (migrations: Migration[]): RepoFacade => {
       }
       hasLockedMigrations = true;
     },
+    recordProcessedMigration: async (migration) => {
+      processedMigrations = [...processedMigrations, migration];
+    },
     removeProcessedMigration: async (key) => {
       processedMigrations = processedMigrations.filter((processedMigration) => {
         return processedMigration.key !== key;
@@ -30,12 +33,6 @@ const testRepoFactory = (migrations: Migration[]): RepoFacade => {
     },
     unlockMigrations: async () => {
       hasLockedMigrations = false;
-    },
-    updateProcessedMigration: async (migration) => {
-      const unmatchedMigrations = processedMigrations.filter((processedMigration) => {
-        return processedMigration.key !== migration.key;
-      });
-      processedMigrations = [...unmatchedMigrations, migration];
     },
   };
 };

--- a/src/utils/types/ProcessedMigration.ts
+++ b/src/utils/types/ProcessedMigration.ts
@@ -1,5 +1,6 @@
 export default interface ProcessedMigration {
   readonly key: string;
-  readonly lastStart: Date;
-  readonly lastBatch: Date;
+  readonly processStart: Date;
+  readonly processEnd: Date;
+  readonly batchStart: Date;
 }


### PR DESCRIPTION
BREAKING CHANGE: Renames fields in `ProcessedMigration` and `updateProcessedMigration` is renamed to `recordProcessedMigration` in the `RepoFacade`.

- Adds `processEnd` date so that the process duration can be calculated from `processStart` and `processEnd`.
- Renames `lastStart` to `processStart`.
- Renames `lastBatch` to `batchStart`.
- Records a `ProcessedMigration` every time a migration is processed rather than just the last time they were processed for better tracing.